### PR TITLE
fix parsing of CN

### DIFF
--- a/SSL/zext_ssl_cert.sh
+++ b/SSL/zext_ssl_cert.sh
@@ -56,7 +56,7 @@ issue_dn=`openssl s_client -servername $servername -host $host -port $port -show
 
 if [ -n "$issue_dn" ]
 then
-    issuer=`echo $issue_dn | sed -n 's/.*CN=*//p'`
+    issuer=`echo $issue_dn | sed -n 's/.*CN\\s*=*//p'`
     echo $issuer
 fi
 ;;


### PR DESCRIPTION
We have "CN = value" on Debian10, openssl version  1.1.1n